### PR TITLE
Fix count distinct null check for dictionary arrays

### DIFF
--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -711,8 +711,8 @@ impl Accumulator for DistinctCountAccumulator {
         }
 
         (0..arr.len()).try_for_each(|index| {
-            if !arr.is_null(index) {
-                let scalar = ScalarValue::try_from_array(arr, index)?;
+            let scalar = ScalarValue::try_from_array(arr, index)?;
+            if !scalar.is_null() {
                 self.values.insert(scalar);
             }
             Ok(())

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -5043,6 +5043,20 @@ select count(distinct column1), count(distinct column2) from dict_test group by 
 statement ok
 drop table dict_test;
 
+## count distinct dictionary with null values
+statement ok
+create table dict_null_test as
+    select arrow_cast(NULL, 'Dictionary(Int32, Utf8)') as d
+    from (values (1), (2), (3), (4), (5));
+
+query I
+select count(distinct d) from dict_null_test;
+----
+0
+
+statement ok
+drop table dict_null_test;
+
 # avg_duration
 
 statement ok


### PR DESCRIPTION
## Summary
- handle nulls in dictionary values when counting distinct values
- add regression test for dictionary arrays containing only nulls

## Testing
- `./dev/rust_lint.sh` *(failed: custom build command for `substrait`)*
- `taplo format --check --colors never` *(failed: line length limit)*
- `cargo test` *(aborted build)*


------
https://chatgpt.com/codex/tasks/task_e_68413135966483248e1cd5ec8b161b72