### PR TITLE
Add experimental filter pushdown API docs

### DIFF
--- a/datafusion/physical-plan/src/filter_pushdown_api.rs
+++ b/datafusion/physical-plan/src/filter_pushdown_api.rs
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Simplified filter pushdown API.
+//!
+//! This module contains an experimental redesign of the
+//! filter pushdown API aimed at reducing the number of
+//! abstractions and making the flow easier to understand.
+//! It is not yet hooked into the rest of the execution
+//! engine but provides the core data structures that new
+//! implementations can build on.
+
+use std::sync::Arc;
+
+use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
+
+/// A predicate with its pushdown support status.
+#[derive(Debug, Clone)]
+pub enum PredicateWithSupport {
+    /// The predicate can be pushed down.
+    Supported(Arc<dyn PhysicalExpr>),
+    /// The predicate must be evaluated locally.
+    Unsupported(Arc<dyn PhysicalExpr>),
+}
+
+impl PredicateWithSupport {
+    /// Returns a reference to the underlying expression.
+    pub fn expr(&self) -> &Arc<dyn PhysicalExpr> {
+        match self {
+            PredicateWithSupport::Supported(expr)
+            | PredicateWithSupport::Unsupported(expr) => expr,
+        }
+    }
+}
+
+/// Collection of predicates with convenience helpers.
+#[derive(Debug, Clone, Default)]
+pub struct Predicates(Vec<PredicateWithSupport>);
+
+impl Predicates {
+    /// Create a new collection from the provided predicates.
+    pub fn new(preds: Vec<PredicateWithSupport>) -> Self {
+        Self(preds)
+    }
+
+    /// Add a predicate to the collection returning a new instance.
+    pub fn with_predicate(mut self, pred: PredicateWithSupport) -> Self {
+        self.0.push(pred);
+        self
+    }
+
+    /// Return all predicates marked as supported.
+    pub fn collect_supported(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        self.0
+            .iter()
+            .filter_map(|p| match p {
+                PredicateWithSupport::Supported(expr) => Some(Arc::clone(expr)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return all predicates marked as unsupported.
+    pub fn collect_unsupported(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        self.0
+            .iter()
+            .filter_map(|p| match p {
+                PredicateWithSupport::Unsupported(expr) => Some(Arc::clone(expr)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns an iterator over all predicates.
+    pub fn iter(&self) -> impl Iterator<Item = &PredicateWithSupport> {
+        self.0.iter()
+    }
+}
+
+/// Result of attempting to push predicates through a node.
+#[derive(Debug, Clone)]
+pub struct FilterPushdownResult<T> {
+    /// Predicates that were pushed into the child node.
+    pub pushed_predicates: Vec<Arc<dyn PhysicalExpr>>,
+    /// Predicates that must remain on the current node.
+    pub retained_predicates: Vec<Arc<dyn PhysicalExpr>>,
+    /// Optional updated execution plan node.
+    pub updated_plan: Option<T>,
+}
+
+impl<T> FilterPushdownResult<T> {
+    /// Create a new result with the provided pushed and retained predicates.
+    pub fn new(
+        pushed_predicates: Vec<Arc<dyn PhysicalExpr>>,
+        retained_predicates: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
+        Self {
+            pushed_predicates,
+            retained_predicates,
+            updated_plan: None,
+        }
+    }
+
+    /// Attach an updated plan node.
+    pub fn with_updated_plan(mut self, plan: T) -> Self {
+        self.updated_plan = Some(plan);
+        self
+    }
+}

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -68,6 +68,7 @@ pub mod execution_plan;
 pub mod explain;
 pub mod filter;
 pub mod filter_pushdown;
+pub mod filter_pushdown_api;
 pub mod joins;
 pub mod limit;
 pub mod memory;

--- a/docs/source/contributor-guide/filter_pushdown_api.md
+++ b/docs/source/contributor-guide/filter_pushdown_api.md
@@ -1,0 +1,34 @@
+# Simplified Filter Pushdown API
+
+This document describes a simplified approach for pushing predicates through
+physical plan nodes. The goal is to reduce the layering of abstractions and
+make the pushdown behaviour easier to reason about.
+
+## Core Data Structures
+
+The new API introduces three main types located in
+`datafusion/physical-plan/src/filter_pushdown_api.rs`:
+
+- `PredicateWithSupport` – associates a predicate with either `Supported` or
+  `Unsupported` status.
+- `Predicates` – convenience wrapper around a collection of
+  `PredicateWithSupport` values.
+- `FilterPushdownResult<T>` – result of attempting to push predicates through a
+  node; contains the pushed predicates, retained predicates and optionally an
+  updated plan node of type `T`.
+
+These types aim to replace the previous combination of `PredicateSupport`,
+`PredicateSupports`, `FilterDescription` and related helpers.
+
+## Usage
+
+Execution plan nodes can declare which predicates they support and return a
+`FilterPushdownResult` describing what was pushed to children and what remains
+local. The API is designed so that `with_*` methods create new objects while
+`mark_*` methods transform existing ones. The focus is on keeping the flow
+explicit and easy to follow.
+
+This implementation is currently experimental and is not yet wired into the
+optimizer. It serves as a reference for future work on improving filter
+pushdown in DataFusion.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,6 +150,7 @@ To get started, see
    contributor-guide/communication
    contributor-guide/development_environment
    contributor-guide/architecture
+   contributor-guide/filter_pushdown_api
    contributor-guide/testing
    contributor-guide/api-health
    contributor-guide/howtos


### PR DESCRIPTION
## Summary
- create new `filter_pushdown_api` module with redesigned API skeleton
- document the simplified API in the contributor guide
- link the new docs from the main index
- expose the module in `physical-plan` crate

## Testing
- `prettier -w {datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md`
- `taplo format --check --colors never`
- `./dev/rust_lint.sh` *(failed: build cancelled)*
- `cargo test` *(failed: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684381718d38832484a14c23d2af90dc