### PR TITLE
Fix pruning test dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-pruning",
  "insta",
  "itertools 0.14.0",
  "log",
@@ -2556,10 +2557,13 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "datafusion-common",
+ "datafusion-expr",
  "datafusion-expr-common",
+ "datafusion-functions-nested",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "insta",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,10 +137,10 @@ datafusion-optimizer = { path = "datafusion/optimizer", version = "48.0.0", defa
 datafusion-physical-expr = { path = "datafusion/physical-expr", version = "48.0.0", default-features = false }
 datafusion-physical-expr-common = { path = "datafusion/physical-expr-common", version = "48.0.0", default-features = false }
 datafusion-physical-optimizer = { path = "datafusion/physical-optimizer", version = "48.0.0" }
-datafusion-pruning = { path = "datafusion/pruning", version = "48.0.0" }
 datafusion-physical-plan = { path = "datafusion/physical-plan", version = "48.0.0" }
 datafusion-proto = { path = "datafusion/proto", version = "48.0.0" }
 datafusion-proto-common = { path = "datafusion/proto-common", version = "48.0.0" }
+datafusion-pruning = { path = "datafusion/pruning", version = "48.0.0" }
 datafusion-session = { path = "datafusion/session", version = "48.0.0" }
 datafusion-spark = { path = "datafusion/spark", version = "48.0.0" }
 datafusion-sql = { path = "datafusion/sql", version = "48.0.0" }

--- a/datafusion/physical-optimizer/Cargo.toml
+++ b/datafusion/physical-optimizer/Cargo.toml
@@ -46,6 +46,7 @@ datafusion-expr-common = { workspace = true, default-features = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+datafusion-pruning = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 recursive = { workspace = true, optional = true }

--- a/datafusion/pruning/Cargo.toml
+++ b/datafusion/pruning/Cargo.toml
@@ -13,10 +13,15 @@ workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-log = { workspace = true }
-arrow-schema = { workspace = true, package = "arrow-schema" }
+arrow-schema = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr-common = { workspace = true, default-features = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+log = { workspace = true }
+
+[dev-dependencies]
+datafusion-expr = { workspace = true }
+datafusion-functions-nested = { workspace = true }
+insta = { workspace = true }


### PR DESCRIPTION
## Summary
- fix manifest for `datafusion-pruning` to include dev-dependencies
- expose pruning crate to physical optimizer
- run taplo formatting

## Testing
- `cargo clippy --all-targets --workspace --features avro,pyarrow,integration-tests -- -D warnings`
- `taplo format --check`
- `cargo test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685bad1704dc8324a733b80e9b0e8e7b