### PR TITLE
Fix projection pruning alias mismatch in recursive CTEs

### DIFF
--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -411,11 +411,25 @@ fn optimize_projections(
         })?;
 
         let projection_beneficial = required_indices.projection_beneficial();
-        let project_exprs = required_indices.get_required_exprs(child.schema());
+        let project_indices = required_indices.clone();
 
         optimize_projections(child, config, required_indices)?.transform_data(
-            |new_input| {
+            move |new_input| {
                 if projection_beneficial {
+                    let project_exprs = if new_input.schema().fields().len()
+                        == project_indices.indices().len()
+                    {
+                        // After optimizing the child, its schema should match
+                        // the requested indices. Use the updated schema to
+                        // construct projection expressions so that any alias
+                        // changes are accounted for.
+                        let tmp_indices = RequiredIndices::new_from_indices(
+                            (0..project_indices.indices().len()).collect(),
+                        );
+                        tmp_indices.get_required_exprs(new_input.schema())
+                    } else {
+                        project_indices.get_required_exprs(new_input.schema())
+                    };
                     add_projection_on_top_if_helpful(new_input, project_exprs)
                 } else {
                     Ok(Transformed::no(new_input))
@@ -750,10 +764,9 @@ fn collect_cte_usage(
             })?;
 
             // compute required indices using the CTE's schema, ignoring
-            // qualifiers from scalar subqueries as they do not appear in the CTE
-            // schema itself
+            // unknown qualifiers that may appear in scalar subqueries
             *indices =
-                std::mem::take(indices).with_exprs_ignore_qualifiers(cte_schema, &exprs);
+                std::mem::take(indices).with_exprs_resolve_columns(cte_schema, &exprs);
 
             for child in plan.inputs() {
                 collect_cte_usage(child, cte_schema, indices)?;

--- a/datafusion/optimizer/src/optimize_projections/required_indices.rs
+++ b/datafusion/optimizer/src/optimize_projections/required_indices.rs
@@ -124,16 +124,20 @@ impl RequiredIndices {
         }
     }
 
-    /// Similar to [`add_expr`] but ignores any qualifiers on the columns when
-    /// locating them within `input_schema`.
-    fn add_expr_ignore_qualifiers(&mut self, input_schema: &DFSchemaRef, expr: &Expr) {
+    /// Adds required indices resolving columns using qualifiers when present,
+    /// but falling back to unqualified lookups if needed.
+    fn add_expr_resolve_columns(&mut self, input_schema: &DFSchemaRef, expr: &Expr) {
         let mut cols = expr.column_refs();
         outer_columns(expr, &mut cols);
         self.indices.reserve(cols.len());
         for col in cols {
-            let unqualified = Column::new_unqualified(&col.name);
-            if let Some(idx) = input_schema.maybe_index_of_column(&unqualified) {
+            if let Some(idx) = input_schema.maybe_index_of_column(col) {
                 self.indices.push(idx);
+            } else if col.relation.is_some() {
+                let unqualified = Column::new_unqualified(&col.name);
+                if let Some(idx) = input_schema.maybe_index_of_column(&unqualified) {
+                    self.indices.push(idx);
+                }
             }
         }
     }
@@ -159,9 +163,9 @@ impl RequiredIndices {
             .compact()
     }
 
-    /// Adds the indices of the fields referred to by `exprs` within
-    /// `schema`, ignoring any qualifiers on the columns.
-    pub fn with_exprs_ignore_qualifiers<'a>(
+    /// Adds the indices of the fields referred to by `exprs` within `schema`,
+    /// attempting qualified lookup first and falling back to unqualified names.
+    pub fn with_exprs_resolve_columns<'a>(
         self,
         schema: &DFSchemaRef,
         exprs: impl IntoIterator<Item = &'a Expr>,
@@ -169,7 +173,7 @@ impl RequiredIndices {
         exprs
             .into_iter()
             .fold(self, |mut acc, expr| {
-                acc.add_expr_ignore_qualifiers(schema, expr);
+                acc.add_expr_resolve_columns(schema, expr);
                 acc
             })
             .compact()

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -396,13 +396,6 @@ fn preprocess_recursive_cte(sql: &str) -> Option<String> {
     let mut rewritten = sql.to_string();
     let mut modified = false;
 
-    if let Some(idx) = rewritten.find(';') {
-        if rewritten[idx + 1..].trim_start().starts_with(')') {
-            rewritten.truncate(idx + 1);
-            modified = true;
-        }
-    }
-
     let upper = rewritten.to_ascii_uppercase();
     if upper.contains(", RECURSIVE") && !upper.trim_start().starts_with("WITH RECURSIVE")
     {


### PR DESCRIPTION
## Summary
- resolve recursive CTE columns using qualifiers when present, falling back to unqualified names
- clean up unused helper methods
- handle recursive keyword rewriting without trimming trailing SQL

## Testing
- `./dev/rust_lint.sh`
- `prettier -w {datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md`
- `taplo format --check`
- `cargo test --quiet` *(failed: command terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686e44c1103083249d07ac070ae62951