### PR TITLE
Store Alias and OuterReferenceColumn on heap

### DIFF
--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -63,7 +63,7 @@ pub fn expr_applicable_for_cols(col_names: &[&str], expr: &Expr) -> bool {
         }
         Expr::Literal(_, _)
         | Expr::Alias(_)
-        | Expr::OuterReferenceColumn(_, _)
+        | Expr::OuterReferenceColumn(_)
         | Expr::ScalarVariable(_, _)
         | Expr::Not(_)
         | Expr::IsNotNull(_)

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2291,7 +2291,7 @@ impl DataFrame {
                 if cols.contains(field) {
                     // Try to cast fill value to column type. If the cast fails, fallback to the original column.
                     match value.clone().cast_to(field.data_type()) {
-                        Ok(fill_value) => Expr::Alias(Alias {
+                        Ok(fill_value) => Expr::Alias(Box::new(Alias {
                             expr: Box::new(Expr::ScalarFunction(ScalarFunction {
                                 func: coalesce(),
                                 args: vec![col(field.name()), lit(fill_value)],
@@ -2299,7 +2299,7 @@ impl DataFrame {
                             relation: None,
                             name: field.name().to_string(),
                             metadata: None,
-                        }),
+                        })),
                         Err(_) => col(field.name()),
                     }
                 } else {

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -595,9 +595,9 @@ impl DefaultPhysicalPlanner {
                         } = &window_fun.as_ref().params;
                         generate_sort_key(partition_by, order_by)
                     }
-                    Expr::Alias(Alias { expr, .. }) => {
+                    Expr::Alias(alias) => {
                         // Convert &Box<T> to &T
-                        match &**expr {
+                        match alias.expr.as_ref() {
                             Expr::WindowFunction(window_fun) => {
                                 let WindowFunctionParams {
                                     ref partition_by,
@@ -1681,7 +1681,7 @@ pub fn create_window_expr(
 ) -> Result<Arc<dyn WindowExpr>> {
     // unpack aliased logical expressions, e.g. "sum(col) over () as total"
     let (name, e) = match e {
-        Expr::Alias(Alias { expr, name, .. }) => (name.clone(), expr.as_ref()),
+        Expr::Alias(alias) => (alias.name.clone(), alias.expr.as_ref()),
         _ => (e.schema_name().to_string(), e),
     };
     create_window_expr_with_name(e, name, logical_schema, execution_props)
@@ -1772,9 +1772,11 @@ pub fn create_aggregate_expr_and_maybe_filter(
 ) -> Result<AggregateExprWithOptionalArgs> {
     // unpack (nested) aliased logical expressions, e.g. "sum(col) as total"
     let (name, human_display, e) = match e {
-        Expr::Alias(Alias { expr, name, .. }) => {
-            (Some(name.clone()), String::default(), expr.as_ref())
-        }
+        Expr::Alias(alias) => (
+            Some(alias.name.clone()),
+            String::default(),
+            alias.expr.as_ref(),
+        ),
         Expr::AggregateFunction(_) => (
             Some(e.schema_name().to_string()),
             e.human_display().to_string(),

--- a/datafusion/core/tests/dataframe/dataframe_functions.rs
+++ b/datafusion/core/tests/dataframe/dataframe_functions.rs
@@ -415,11 +415,11 @@ async fn test_fn_approx_percentile_cont() -> Result<()> {
     ");
 
     // the arg2 parameter is a complex expr, but it can be evaluated to the literal value
-    let alias_expr = Expr::Alias(Alias::new(
+    let alias_expr = Expr::Alias(Box::new(Alias::new(
         cast(lit(0.5), DataType::Float32),
         None::<&str>,
         "arg_2".to_string(),
-    ));
+    )));
     let expr = approx_percentile_cont(col("b").sort(true, false), alias_expr, None);
     let df = create_test_table().await?;
     let batches = df.aggregate(vec![], vec![expr]).unwrap().collect().await?;
@@ -435,11 +435,11 @@ async fn test_fn_approx_percentile_cont() -> Result<()> {
     "
     );
 
-    let alias_expr = Expr::Alias(Alias::new(
+    let alias_expr = Expr::Alias(Box::new(Alias::new(
         cast(lit(0.1), DataType::Float32),
         None::<&str>,
         "arg_2".to_string(),
-    ));
+    )));
     let expr = approx_percentile_cont(col("b").sort(false, false), alias_expr, None);
     let df = create_test_table().await?;
     let batches = df.aggregate(vec![], vec![expr]).unwrap().collect().await?;

--- a/datafusion/core/tests/user_defined/expr_planner.rs
+++ b/datafusion/core/tests/user_defined/expr_planner.rs
@@ -55,11 +55,11 @@ impl ExprPlanner for MyCustomPlanner {
                 })))
             }
             BinaryOperator::Question => {
-                Ok(PlannerResult::Planned(Expr::Alias(Alias::new(
+                Ok(PlannerResult::Planned(Expr::Alias(Box::new(Alias::new(
                     Expr::Literal(ScalarValue::Boolean(Some(true)), None),
                     None::<&str>,
                     format!("{} ? {}", expr.left, expr.right),
-                ))))
+                )))))
             }
             _ => Ok(PlannerResult::Original(expr)),
         }

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -279,7 +279,7 @@ use sqlparser::ast::{
 #[derive(Clone, PartialEq, PartialOrd, Eq, Debug, Hash)]
 pub enum Expr {
     /// An expression with a specific name.
-    Alias(Alias),
+    Alias(Box<Alias>),
     /// A named reference to a qualified field in a schema.
     Column(Column),
     /// A named reference to a variable in a registry.
@@ -362,7 +362,7 @@ pub enum Expr {
     Placeholder(Placeholder),
     /// A placeholder which holds a reference to a qualified field
     /// in the outer query, used for correlated sub queries.
-    OuterReferenceColumn(DataType, Column),
+    OuterReferenceColumn(Box<OuterReferenceColumn>),
     /// Unnest expression
     Unnest(Unnest),
 }
@@ -1229,6 +1229,21 @@ pub struct Placeholder {
     pub data_type: Option<DataType>,
 }
 
+/// A reference to a column in an outer query, used for correlated subqueries.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct OuterReferenceColumn {
+    /// The data type of the referenced column
+    pub data_type: DataType,
+    /// The referenced column
+    pub column: Column,
+}
+
+impl OuterReferenceColumn {
+    pub fn new(data_type: DataType, column: Column) -> Self {
+        Self { data_type, column }
+    }
+}
+
 impl Placeholder {
     /// Create a new Placeholder expression
     pub fn new(id: String, data_type: Option<DataType>) -> Self {
@@ -1443,7 +1458,7 @@ impl Expr {
             Expr::Case { .. } => "Case",
             Expr::Cast { .. } => "Cast",
             Expr::Column(..) => "Column",
-            Expr::OuterReferenceColumn(_, _) => "Outer",
+            Expr::OuterReferenceColumn(_) => "Outer",
             Expr::Exists { .. } => "Exists",
             Expr::GroupingSet(..) => "GroupingSet",
             Expr::InList { .. } => "InList",
@@ -1569,7 +1584,7 @@ impl Expr {
 
     /// Return `self AS name` alias expression
     pub fn alias(self, name: impl Into<String>) -> Expr {
-        Expr::Alias(Alias::new(self, None::<&str>, name.into()))
+        Expr::Alias(Box::new(Alias::new(self, None::<&str>, name.into())))
     }
 
     /// Return `self AS name` alias expression with metadata
@@ -1592,7 +1607,9 @@ impl Expr {
         name: impl Into<String>,
         metadata: Option<FieldMetadata>,
     ) -> Expr {
-        Expr::Alias(Alias::new(self, None::<&str>, name.into()).with_metadata(metadata))
+        Expr::Alias(Box::new(
+            Alias::new(self, None::<&str>, name.into()).with_metadata(metadata),
+        ))
     }
 
     /// Return `self AS name` alias expression with a specific qualifier
@@ -1601,7 +1618,7 @@ impl Expr {
         relation: Option<impl Into<TableReference>>,
         name: impl Into<String>,
     ) -> Expr {
-        Expr::Alias(Alias::new(self, relation, name.into()))
+        Expr::Alias(Box::new(Alias::new(self, relation, name.into())))
     }
 
     /// Return `self AS name` alias expression with a specific qualifier and metadata
@@ -1625,7 +1642,9 @@ impl Expr {
         name: impl Into<String>,
         metadata: Option<FieldMetadata>,
     ) -> Expr {
-        Expr::Alias(Alias::new(self, relation, name.into()).with_metadata(metadata))
+        Expr::Alias(Box::new(
+            Alias::new(self, relation, name.into()).with_metadata(metadata),
+        ))
     }
 
     /// Remove an alias from an expression if one exists.
@@ -1906,7 +1925,7 @@ impl Expr {
 
     /// Return true if the expression contains out reference(correlated) expressions.
     pub fn contains_outer(&self) -> bool {
-        self.exists(|expr| Ok(matches!(expr, Expr::OuterReferenceColumn { .. })))
+        self.exists(|expr| Ok(matches!(expr, Expr::OuterReferenceColumn(_))))
             .expect("exists closure is infallible")
     }
 
@@ -2018,7 +2037,7 @@ impl Expr {
             | Expr::SimilarTo(..)
             | Expr::Not(..)
             | Expr::Negative(..)
-            | Expr::OuterReferenceColumn(_, _)
+            | Expr::OuterReferenceColumn(_)
             | Expr::TryCast(..)
             | Expr::Unnest(..)
             | Expr::Wildcard { .. }
@@ -2601,9 +2620,9 @@ impl HashNode for Expr {
             Expr::Placeholder(place_holder) => {
                 place_holder.hash(state);
             }
-            Expr::OuterReferenceColumn(data_type, column) => {
-                data_type.hash(state);
-                column.hash(state);
+            Expr::OuterReferenceColumn(outer) => {
+                outer.data_type.hash(state);
+                outer.column.hash(state);
             }
             Expr::Unnest(Unnest { expr: _expr }) => {}
         };
@@ -3169,10 +3188,12 @@ pub const UNNEST_COLUMN_PREFIX: &str = "UNNEST";
 impl Display for Expr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Expr::Alias(Alias { expr, name, .. }) => write!(f, "{expr} AS {name}"),
+            Expr::Alias(alias) => {
+                write!(f, "{} AS {}", alias.expr, alias.name)
+            }
             Expr::Column(c) => write!(f, "{c}"),
-            Expr::OuterReferenceColumn(_, c) => {
-                write!(f, "{OUTER_REFERENCE_COLUMN_PREFIX}({c})")
+            Expr::OuterReferenceColumn(outer) => {
+                write!(f, "{OUTER_REFERENCE_COLUMN_PREFIX}({})", outer.column)
             }
             Expr::ScalarVariable(_, var_names) => write!(f, "{}", var_names.join(".")),
             Expr::Literal(v, metadata) => {

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -69,7 +69,7 @@ pub fn col(ident: impl Into<Column>) -> Expr {
 /// Create an out reference column which hold a reference that has been resolved to a field
 /// outside of the current plan.
 pub fn out_ref_col(dt: DataType, ident: impl Into<Column>) -> Expr {
-    Expr::OuterReferenceColumn(dt, ident.into())
+    Expr::OuterReferenceColumn(Box::new(OuterReferenceColumn::new(dt, ident.into())))
 }
 
 /// Create an unqualified column expression from the provided name, without normalizing

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -174,9 +174,9 @@ pub fn create_col_from_scalar_expr(
     subqry_alias: String,
 ) -> Result<Column> {
     match scalar_expr {
-        Expr::Alias(Alias { name, .. }) => Ok(Column::new(
+        Expr::Alias(alias) => Ok(Column::new(
             Some::<TableReference>(subqry_alias.into()),
-            name,
+            &alias.name,
         )),
         Expr::Column(col) => Ok(col.with_relation(subqry_alias.into())),
         _ => {
@@ -200,8 +200,8 @@ pub fn unnormalize_cols(exprs: impl IntoIterator<Item = Expr>) -> Vec<Expr> {
 pub fn strip_outer_reference(expr: Expr) -> Expr {
     expr.transform(|expr| {
         Ok({
-            if let Expr::OuterReferenceColumn(_, col) = expr {
-                Transformed::yes(Expr::Column(col))
+            if let Expr::OuterReferenceColumn(outer) = expr {
+                Transformed::yes(Expr::Column(outer.column))
             } else {
                 Transformed::no(expr)
             }
@@ -250,9 +250,10 @@ fn coerce_exprs_for_schema(
             let new_type = dst_schema.field(idx).data_type();
             if new_type != &expr.get_type(src_schema)? {
                 match expr {
-                    Expr::Alias(Alias { expr, name, .. }) => {
-                        Ok(expr.cast_to(new_type, src_schema)?.alias(name))
-                    }
+                    Expr::Alias(alias) => Ok(alias
+                        .expr
+                        .cast_to(new_type, src_schema)?
+                        .alias(alias.name.clone())),
                     #[expect(deprecated)]
                     Expr::Wildcard { .. } => Ok(expr),
                     _ => expr.cast_to(new_type, src_schema),
@@ -268,7 +269,7 @@ fn coerce_exprs_for_schema(
 #[inline]
 pub fn unalias(expr: Expr) -> Expr {
     match expr {
-        Expr::Alias(Alias { expr, .. }) => unalias(*expr),
+        Expr::Alias(alias) => unalias(*alias.expr),
         _ => expr,
     }
 }

--- a/datafusion/expr/src/expr_rewriter/order_by.rs
+++ b/datafusion/expr/src/expr_rewriter/order_by.rs
@@ -137,8 +137,8 @@ fn rewrite_in_terms_of_projection(
 /// so avg(c) as average will match avgc
 fn expr_match(needle: &Expr, expr: &Expr) -> bool {
     // check inside aliases
-    if let Expr::Alias(Alias { expr, .. }) = &expr {
-        expr.as_ref() == needle
+    if let Expr::Alias(alias) = &expr {
+        alias.expr.as_ref() == needle
     } else {
         expr == needle
     }

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -103,16 +103,16 @@ impl ExprSchemable for Expr {
     #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
     fn get_type(&self, schema: &dyn ExprSchema) -> Result<DataType> {
         match self {
-            Expr::Alias(Alias { expr, name, .. }) => match &**expr {
+            Expr::Alias(alias) => match alias.expr.as_ref() {
                 Expr::Placeholder(Placeholder { data_type, .. }) => match &data_type {
-                    None => schema.data_type(&Column::from_name(name)).cloned(),
+                    None => schema.data_type(&Column::from_name(&alias.name)).cloned(),
                     Some(dt) => Ok(dt.clone()),
                 },
-                _ => expr.get_type(schema),
+                _ => alias.expr.get_type(schema),
             },
             Expr::Negative(expr) => expr.get_type(schema),
             Expr::Column(c) => Ok(schema.data_type(c)?.clone()),
-            Expr::OuterReferenceColumn(ty, _) => Ok(ty.clone()),
+            Expr::OuterReferenceColumn(outer) => Ok(outer.data_type.clone()),
             Expr::ScalarVariable(ty, _) => Ok(ty.clone()),
             Expr::Literal(l, _) => Ok(l.data_type()),
             Expr::Case(case) => {
@@ -242,8 +242,8 @@ impl ExprSchemable for Expr {
     /// column that does not exist in the schema.
     fn nullable(&self, input_schema: &dyn ExprSchema) -> Result<bool> {
         match self {
-            Expr::Alias(Alias { expr, .. }) | Expr::Not(expr) | Expr::Negative(expr) => {
-                expr.nullable(input_schema)
+            Expr::Alias(alias) | Expr::Not(expr) | Expr::Negative(expr) => {
+                alias.expr.nullable(input_schema)
             }
 
             Expr::InList(InList { expr, list, .. }) => {
@@ -276,7 +276,7 @@ impl ExprSchemable for Expr {
                 || high.nullable(input_schema)?),
 
             Expr::Column(c) => input_schema.nullable(c),
-            Expr::OuterReferenceColumn(_, _) => Ok(true),
+            Expr::OuterReferenceColumn(_) => Ok(true),
             Expr::Literal(value, _) => Ok(value.is_null()),
             Expr::Case(case) => {
                 // This expression is nullable if any of the input expressions are nullable
@@ -380,13 +380,14 @@ impl ExprSchemable for Expr {
         let (relation, schema_name) = self.qualified_name();
         #[allow(deprecated)]
         let field = match self {
-            Expr::Alias(Alias {
-                expr,
-                name,
-                metadata,
-                ..
-            }) => {
-                let field = match &**expr {
+            Expr::Alias(alias) => {
+                let Alias {
+                    expr,
+                    name,
+                    metadata,
+                    ..
+                } = alias.as_ref();
+                let field = match expr.as_ref() {
                     Expr::Placeholder(Placeholder { data_type, .. }) => {
                         match &data_type {
                             None => schema
@@ -411,9 +412,11 @@ impl ExprSchemable for Expr {
             }
             Expr::Negative(expr) => expr.to_field(schema).map(|(_, f)| f),
             Expr::Column(c) => schema.field_from_column(c).map(|f| Arc::new(f.clone())),
-            Expr::OuterReferenceColumn(ty, _) => {
-                Ok(Arc::new(Field::new(&schema_name, ty.clone(), true)))
-            }
+            Expr::OuterReferenceColumn(outer) => Ok(Arc::new(Field::new(
+                &schema_name,
+                outer.data_type.clone(),
+                true,
+            ))),
             Expr::ScalarVariable(ty, _) => {
                 Ok(Arc::new(Field::new(&schema_name, ty.clone(), true)))
             }

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -44,8 +44,8 @@ impl TreeNode for Expr {
         f: F,
     ) -> Result<TreeNodeRecursion> {
         match self {
-            Expr::Alias(Alias { expr, .. })
-            | Expr::Unnest(Unnest { expr })
+            Expr::Alias(alias) => alias.expr.apply_elements(f),
+            Expr::Unnest(Unnest { expr })
             | Expr::Not(expr)
             | Expr::IsNotNull(expr)
             | Expr::IsTrue(expr)
@@ -71,7 +71,7 @@ impl TreeNode for Expr {
             #[expect(deprecated)]
             Expr::Column(_)
             // Treat OuterReferenceColumn as a leaf expression
-            | Expr::OuterReferenceColumn(_, _)
+            | Expr::OuterReferenceColumn(_)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_, _)
             | Expr::Exists { .. }
@@ -122,7 +122,7 @@ impl TreeNode for Expr {
             Expr::Column(_)
             | Expr::Wildcard { .. }
             | Expr::Placeholder(Placeholder { .. })
-            | Expr::OuterReferenceColumn(_, _)
+            | Expr::OuterReferenceColumn(_)
             | Expr::Exists { .. }
             | Expr::ScalarSubquery(_)
             | Expr::ScalarVariable(_, _)
@@ -130,14 +130,17 @@ impl TreeNode for Expr {
             Expr::Unnest(Unnest { expr, .. }) => expr
                 .map_elements(f)?
                 .update_data(|expr| Expr::Unnest(Unnest { expr })),
-            Expr::Alias(Alias {
-                expr,
-                relation,
-                name,
-                metadata,
-            }) => f(*expr)?.update_data(|e| {
-                e.alias_qualified_with_metadata(relation, name, metadata)
-            }),
+            Expr::Alias(alias) => {
+                let Alias {
+                    expr,
+                    relation,
+                    name,
+                    metadata,
+                } = *alias;
+                f(expr)?.update_data(|e| {
+                    e.alias_qualified_with_metadata(relation, name, metadata)
+                })
+            }
             Expr::InSubquery(InSubquery {
                 expr,
                 subquery,

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -304,7 +304,7 @@ pub fn expr_to_columns(expr: &Expr, accum: &mut HashSet<Column>) -> Result<()> {
             | Expr::ScalarSubquery(_)
             | Expr::Wildcard { .. }
             | Expr::Placeholder(_)
-            | Expr::OuterReferenceColumn { .. } => {}
+            | Expr::OuterReferenceColumn(_) => {}
         }
         Ok(TreeNodeRecursion::Continue)
     })
@@ -619,7 +619,7 @@ pub fn find_window_exprs<'a>(exprs: impl IntoIterator<Item = &'a Expr>) -> Vec<E
 /// (depth first), with duplicates omitted.
 pub fn find_out_reference_exprs(expr: &Expr) -> Vec<Expr> {
     find_exprs_in_expr(expr, &|nested_expr| {
-        matches!(nested_expr, Expr::OuterReferenceColumn { .. })
+        matches!(nested_expr, Expr::OuterReferenceColumn(_))
     })
 }
 
@@ -944,7 +944,7 @@ fn split_conjunction_impl<'a>(expr: &'a Expr, mut exprs: Vec<&'a Expr>) -> Vec<&
             let exprs = split_conjunction_impl(left, exprs);
             split_conjunction_impl(right, exprs)
         }
-        Expr::Alias(Alias { expr, .. }) => split_conjunction_impl(expr, exprs),
+        Expr::Alias(alias) => split_conjunction_impl(alias.expr.as_ref(), exprs),
         other => {
             exprs.push(other);
             exprs
@@ -968,7 +968,7 @@ pub fn iter_conjunction(expr: &Expr) -> impl Iterator<Item = &Expr> {
                     stack.push(right);
                     stack.push(left);
                 }
-                Expr::Alias(Alias { expr, .. }) => stack.push(expr),
+                Expr::Alias(alias) => stack.push(alias.expr.as_ref()),
                 other => return Some(other),
             }
         }
@@ -992,7 +992,7 @@ pub fn iter_conjunction_owned(expr: Expr) -> impl Iterator<Item = Expr> {
                     stack.push(*right);
                     stack.push(*left);
                 }
-                Expr::Alias(Alias { expr, .. }) => stack.push(*expr),
+                Expr::Alias(alias) => stack.push(*alias.expr),
                 other => return Some(other),
             }
         }
@@ -1061,9 +1061,7 @@ fn split_binary_owned_impl(
             let exprs = split_binary_owned_impl(*left, operator, exprs);
             split_binary_owned_impl(*right, operator, exprs)
         }
-        Expr::Alias(Alias { expr, .. }) => {
-            split_binary_owned_impl(*expr, operator, exprs)
-        }
+        Expr::Alias(alias) => split_binary_owned_impl(*alias.expr, operator, exprs),
         other => {
             exprs.push(other);
             exprs
@@ -1088,7 +1086,7 @@ fn split_binary_impl<'a>(
             let exprs = split_binary_impl(left, operator, exprs);
             split_binary_impl(right, operator, exprs)
         }
-        Expr::Alias(Alias { expr, .. }) => split_binary_impl(expr, operator, exprs),
+        Expr::Alias(alias) => split_binary_impl(alias.expr.as_ref(), operator, exprs),
         other => {
             exprs.push(other);
             exprs

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -589,7 +589,7 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
             | Expr::Wildcard { .. }
             | Expr::GroupingSet(_)
             | Expr::Placeholder(_)
-            | Expr::OuterReferenceColumn(_, _) => Ok(Transformed::no(expr)),
+            | Expr::OuterReferenceColumn(_) => Ok(Transformed::no(expr)),
         }
     }
 }

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -509,16 +509,21 @@ fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Project
 
         // do not rewrite top level Aliases (rewriter will remove all aliases within exprs)
         match expr {
-            Expr::Alias(Alias {
-                expr,
-                relation,
-                name,
-                metadata,
-            }) => rewrite_expr(*expr, &prev_projection).map(|result| {
-                result.update_data(|expr| {
-                    Expr::Alias(Alias::new(expr, relation, name).with_metadata(metadata))
+            Expr::Alias(alias) => {
+                let Alias {
+                    expr,
+                    relation,
+                    name,
+                    metadata,
+                } = *alias;
+                rewrite_expr(expr, &prev_projection).map(|result| {
+                    result.update_data(|expr| {
+                        Expr::Alias(Box::new(
+                            Alias::new(expr, relation, name).with_metadata(metadata),
+                        ))
+                    })
                 })
-            }),
+            }
             e => rewrite_expr(e, &prev_projection),
         }
     })?;
@@ -637,8 +642,8 @@ fn outer_columns<'a>(expr: &'a Expr, columns: &mut HashSet<&'a Column>) {
     // inspect_expr_pre doesn't handle subquery references, so find them explicitly
     expr.apply(|expr| {
         match expr {
-            Expr::OuterReferenceColumn(_, col) => {
-                columns.insert(col);
+            Expr::OuterReferenceColumn(outer) => {
+                columns.insert(&outer.column);
             }
             Expr::ScalarSubquery(subquery) => {
                 outer_columns_helper_multi(&subquery.outer_ref_columns, columns);

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -262,7 +262,7 @@ fn can_evaluate_as_join_condition(predicate: &Expr) -> Result<bool> {
         Expr::Exists { .. }
         | Expr::InSubquery(_)
         | Expr::ScalarSubquery(_)
-        | Expr::OuterReferenceColumn(_, _)
+        | Expr::OuterReferenceColumn(_)
         | Expr::Unnest(_) => {
             is_evaluate = false;
             Ok(TreeNodeRecursion::Stop)

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -628,7 +628,7 @@ impl<'a> ConstEvaluator<'a> {
             Expr::AggregateFunction { .. }
             | Expr::ScalarVariable(_, _)
             | Expr::Column(_)
-            | Expr::OuterReferenceColumn(_, _)
+            | Expr::OuterReferenceColumn(_)
             | Expr::Exists { .. }
             | Expr::InSubquery(_)
             | Expr::ScalarSubquery(_)

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -343,7 +343,7 @@ pub fn parse_expr(
                 }
             }
         }
-        ExprType::Alias(alias) => Ok(Expr::Alias(Alias::new(
+        ExprType::Alias(alias) => Ok(Expr::Alias(Box::new(Alias::new(
             parse_required_expr(alias.expr.as_deref(), registry, "expr", codec)?,
             alias
                 .relation
@@ -351,7 +351,7 @@ pub fn parse_expr(
                 .map(|r| TableReference::try_from(r.clone()))
                 .transpose()?,
             alias.alias.clone(),
-        ))),
+        )))),
         ExprType::IsNullExpr(is_null) => Ok(Expr::IsNull(Box::new(parse_required_expr(
             is_null.expr.as_deref(),
             registry,

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -198,12 +198,13 @@ pub fn serialize_expr(
         Expr::Column(c) => protobuf::LogicalExprNode {
             expr_type: Some(ExprType::Column(c.into())),
         },
-        Expr::Alias(Alias {
-            expr,
-            relation,
-            name,
-            metadata,
-        }) => {
+        Expr::Alias(alias) => {
+            let Alias {
+                expr,
+                relation,
+                name,
+                metadata,
+            } = alias.as_ref();
             let alias = Box::new(protobuf::AliasNode {
                 expr: Some(Box::new(serialize_expr(expr.as_ref(), codec)?)),
                 relation: relation
@@ -568,7 +569,7 @@ pub fn serialize_expr(
         Expr::ScalarSubquery(_)
         | Expr::InSubquery(_)
         | Expr::Exists { .. }
-        | Expr::OuterReferenceColumn { .. } => {
+        | Expr::OuterReferenceColumn(_) => {
             // we would need to add logical plan operators to datafusion.proto to support this
             // see discussion in https://github.com/apache/datafusion/issues/2565
             return Err(Error::General("Proto serialization error: Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists { .. } | Exp:OuterReferenceColumn not supported".to_string()));

--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -74,10 +74,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     outer.qualified_field_with_unqualified_name(normalize_ident.as_str())
                 {
                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
-                    return Ok(Expr::OuterReferenceColumn(
-                        field.data_type().clone(),
-                        Column::from((qualifier, field)),
-                    ));
+                    return Ok(Expr::OuterReferenceColumn(Box::new(
+                        OuterReferenceColumn::new(
+                            field.data_type().clone(),
+                            Column::from((qualifier, field)),
+                        ),
+                    )));
                 }
             }
 
@@ -181,10 +183,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 // Found matching field with no spare identifier(s)
                                 Some((field, qualifier, _nested_names)) => {
                                     // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
-                                    Ok(Expr::OuterReferenceColumn(
-                                        field.data_type().clone(),
-                                        Column::from((qualifier, field)),
-                                    ))
+                                    Ok(Expr::OuterReferenceColumn(Box::new(
+                                        OuterReferenceColumn::new(
+                                            field.data_type().clone(),
+                                            Column::from((qualifier, field)),
+                                        ),
+                                    )))
                                 }
                                 // Found no matching field, will return a default
                                 None => {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -512,7 +512,7 @@ impl Unparser<'_> {
             Expr::Placeholder(p) => {
                 Ok(ast::Expr::value(ast::Value::Placeholder(p.id.to_string())))
             }
-            Expr::OuterReferenceColumn(_, col) => self.col_to_sql(col),
+            Expr::OuterReferenceColumn(outer) => self.col_to_sql(&outer.column),
             Expr::Unnest(unnest) => self.unnest_to_sql(unnest),
         }
     }

--- a/datafusion/substrait/src/logical_plan/producer/expr/mod.rs
+++ b/datafusion/substrait/src/logical_plan/producer/expr/mod.rs
@@ -144,7 +144,7 @@ pub fn to_substrait_rex(
         Expr::Wildcard { .. } => not_impl_err!("Cannot convert {expr:?} to Substrait"),
         Expr::GroupingSet(expr) => not_impl_err!("Cannot convert {expr:?} to Substrait"),
         Expr::Placeholder(expr) => not_impl_err!("Cannot convert {expr:?} to Substrait"),
-        Expr::OuterReferenceColumn(_, _) => {
+        Expr::OuterReferenceColumn(_) => {
             not_impl_err!("Cannot convert {expr:?} to Substrait")
         }
         Expr::Unnest(expr) => not_impl_err!("Cannot convert {expr:?} to Substrait"),


### PR DESCRIPTION
## Summary
- box `Alias` and `OuterReferenceColumn` in `Expr` to shrink enum size
- update construction and pattern matches for new boxed variants
- adjust utilities, optimizers and SQL handling

## Testing
- `cargo fmt`
- `prettier -w {datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md`
- `taplo format --check`
- `cargo test --lib --bins` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68765b2c65a483248d294083b4becb00