### PR TITLE
Refactor ScalarUDF hashing and equality

### DIFF
--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -33,6 +33,36 @@ use std::{
     ptr,
     sync::Arc,
 };
+
+/// Helper trait to provide hashing for trait objects based on [`Hash`].
+pub trait UdfHash {
+    /// Compute a deterministic hash value for this UDF
+    fn udf_hash(&self) -> u64;
+}
+
+/// Helper trait to provide equality for trait objects based on [`PartialEq`].
+pub trait UdfEq {
+    /// Compare this UDF to another trait object
+    fn udf_eq(&self, other: &dyn Any) -> bool;
+}
+
+impl<T: Hash + Any> UdfHash for T {
+    fn udf_hash(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.type_id().hash(&mut hasher);
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<T: PartialEq + Any> UdfEq for T {
+    fn udf_eq(&self, other: &dyn Any) -> bool {
+        match other.downcast_ref::<T>() {
+            Some(other) => self == other,
+            None => false,
+        }
+    }
+}
 /// Logical representation of a Scalar User Defined Function.
 ///
 /// A scalar function produces a single row output for each row of input. This
@@ -65,7 +95,7 @@ impl PartialEq for ScalarUDF {
         if Arc::ptr_eq(&self.inner, &other.inner) {
             true
         } else {
-            self.inner.equals(other.inner.as_ref())
+            self.inner.eq(other.inner.as_ref())
         }
     }
 }
@@ -84,7 +114,7 @@ impl Eq for ScalarUDF {}
 
 impl Hash for ScalarUDF {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.hash_value().hash(state)
+        self.inner.hash().hash(state)
     }
 }
 
@@ -416,7 +446,7 @@ pub struct ReturnFieldArgs<'a> {
 /// // Call the function `add_one(col)`
 /// let expr = add_one.call(vec![col("a")]);
 /// ```
-pub trait ScalarUDFImpl: Debug + Send + Sync {
+pub trait ScalarUDFImpl: Send + Sync + UdfHash + UdfEq + Any {
     // Note: When adding any methods (with default implementations), remember to add them also
     // into the AliasedScalarUDFImpl below!
 
@@ -726,7 +756,7 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// use datafusion_common::{not_impl_err, Result};
     /// use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature};
     ///
-    /// #[derive(Debug, PartialEq)]
+    /// #[derive(Debug, Clone, PartialEq, Hash)]
     /// struct MyUdf {
     ///  param: i32,
     ///  signature: Signature,
@@ -748,65 +778,18 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     ///    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
     ///        not_impl_err!("not used")
     ///    }
-    ///     fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
-    ///         if let Some(other) = other.as_any().downcast_ref::<Self>() {
-    ///             self == other
-    ///         } else {
-    ///             false
-    ///         }
-    ///     }
-    ///     fn hash_value(&self) -> u64 {
-    ///         let mut hasher = DefaultHasher::new();
-    ///         self.param.hash(&mut hasher);
-    ///         self.name().hash(&mut hasher);
-    ///         hasher.finish()
-    ///     }
     /// }
     /// ```
     ///
-    /// # Notes
-    /// - This method must be consistent with [`Self::hash_value`]. If `equals` returns true for two UDFs,
-    ///   their hash values must also be the same.
-    /// - Ensure that the implementation does not panic or cause undefined behavior for any input.
-    fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
-        // 1. If the pointers are identical, it’s definitely the same UDF.
-        if ptr::eq(self.as_any(), other.as_any()) {
-            return true;
-        }
-
-        // 2. Otherwise, check that they’re the same concrete Rust type.
-        let self_any = self.as_any();
-        let other_any = other.as_any();
-        if self_any.type_id() != other_any.type_id() {
-            // Different types can never be equal.
-            return false;
-        }
-
-        // 3. Now we know they're the same struct type. In theory, since Rust moves
-        //    values by `memcpy`-ing their bytes, we could `memcmp` them byte-for-byte:
-        //
-        //    However, Rust doesn't guarantee that padding bytes are set the same way,
-        //    so two equal structs might have different padding and compare as not equal.
-        //
-        //    If your UDF type has no padding, or you make sure all padding is zeroed
-        //    (for example, with #[repr(C)] and a safe initializer), you can use memcmp
-        //    Otherwise, it's safer to just return false.
-
-        // 4. Fallback: we can’t prove they’re identical, so we say “not equal.”
-        false
+    /// The default implementations of [`Self::eq`] and [`Self::hash`] use these
+    /// derived traits.
+    fn eq(&self, other: &dyn ScalarUDFImpl) -> bool {
+        self.udf_eq(other.as_any())
     }
 
     /// Returns a hash value for this scalar UDF.
-    ///
-    /// Allows customizing the hash code of scalar UDFs. Similarly to [`Hash`] and [`Eq`],
-    /// if [`Self::equals`] returns true for two UDFs, their `hash_value`s must be the same.
-    ///
-    /// By default, hashes [`Self::name`] and [`Self::signature`].
-    fn hash_value(&self) -> u64 {
-        let hasher = &mut DefaultHasher::new();
-        self.name().hash(hasher);
-        self.signature().hash(hasher);
-        hasher.finish()
+    fn hash(&self) -> u64 {
+        self.udf_hash()
     }
 
     /// Returns the documentation for this Scalar UDF.
@@ -910,17 +893,16 @@ impl ScalarUDFImpl for AliasedScalarUDFImpl {
         self.inner.coerce_types(arg_types)
     }
 
-    fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
+    fn eq(&self, other: &dyn ScalarUDFImpl) -> bool {
         if let Some(other) = other.as_any().downcast_ref::<AliasedScalarUDFImpl>() {
-            self.inner.equals(other.inner.as_ref()) && self.aliases == other.aliases
+            self.inner.eq(other.inner.as_ref()) && self.aliases == other.aliases
         } else {
             false
         }
     }
-
-    fn hash_value(&self) -> u64 {
+    fn hash(&self) -> u64 {
         let hasher = &mut DefaultHasher::new();
-        self.inner.hash_value().hash(hasher);
+        self.inner.hash().hash(hasher);
         self.aliases.hash(hasher);
         hasher.finish()
     }

--- a/datafusion/expr/tests/udf_equals.rs
+++ b/datafusion/expr/tests/udf_equals.rs
@@ -20,11 +20,8 @@ use datafusion_common::{not_impl_err, Result};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
-use std::{
-    any::Any,
-    hash::{Hash, Hasher},
-};
-#[derive(Debug, PartialEq)]
+use std::any::Any;
+#[derive(Debug, Clone, PartialEq, Hash)]
 struct ParamUdf {
     param: i32,
     signature: Signature,
@@ -55,22 +52,9 @@ impl ScalarUDFImpl for ParamUdf {
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         not_impl_err!("not used")
     }
-    fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<ParamUdf>() {
-            self == other
-        } else {
-            false
-        }
-    }
-    fn hash_value(&self) -> u64 {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        self.param.hash(&mut hasher);
-        self.signature.hash(&mut hasher);
-        hasher.finish()
-    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 #[allow(dead_code)]
 struct SignatureUdf {
     signature: Signature,
@@ -100,16 +84,9 @@ impl ScalarUDFImpl for SignatureUdf {
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         not_impl_err!("not used")
     }
-    fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<SignatureUdf>() {
-            self.type_id() == other.type_id()
-        } else {
-            false
-        }
-    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 #[allow(dead_code)]
 struct DefaultParamUdf {
     param: i32,

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -52,7 +52,7 @@ pub mod return_type_args;
 
 /// A stable struct for sharing a [`ScalarUDF`] across FFI boundaries.
 #[repr(C)]
-#[derive(Debug, StableAbi)]
+#[derive(Debug, StableAbi, PartialEq, Hash)]
 #[allow(non_camel_case_types)]
 pub struct FFI_ScalarUDF {
     /// FFI equivalent to the `name` of a [`ScalarUDF`]
@@ -275,7 +275,7 @@ impl Drop for FFI_ScalarUDF {
 /// The ForeignScalarUDF is to be used by the caller of the UDF, so it has
 /// no knowledge or access to the private data. All interaction with the UDF
 /// must occur through the functions defined in FFI_ScalarUDF.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ForeignScalarUDF {
     name: String,
     aliases: Vec<String>,

--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -80,7 +80,7 @@ use datafusion_macros::user_doc;
         description = "[Arrow data type](https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html) name to cast to, as a string. The format is the same as that returned by [`arrow_typeof`]"
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ArrowCastFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/arrowtypeof.rs
+++ b/datafusion/functions/src/core/arrowtypeof.rs
@@ -40,7 +40,7 @@ use std::any::Any;
         description = "Expression to evaluate. The expression can be a constant, column, or function, and any combination of operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ArrowTypeOfFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/coalesce.rs
+++ b/datafusion/functions/src/core/coalesce.rs
@@ -46,7 +46,7 @@ use std::any::Any;
         description = "Expression to use if previous expressions are _null_. Can be a constant, column, or function, and any combination of arithmetic operators. Pass as many expression arguments as necessary."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct CoalesceFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -75,7 +75,7 @@ use std::sync::Arc;
         description = "The field name in the map or struct to retrieve data for. Must evaluate to a string."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct GetFieldFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/greatest.rs
+++ b/datafusion/functions/src/core/greatest.rs
@@ -53,7 +53,7 @@ const SORT_OPTIONS: SortOptions = SortOptions {
         description = "Expressions to compare and return the greatest value.. Can be a constant, column, or function, and any combination of arithmetic operators. Pass as many expression arguments as necessary."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct GreatestFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/least.rs
+++ b/datafusion/functions/src/core/least.rs
@@ -53,7 +53,7 @@ const SORT_OPTIONS: SortOptions = SortOptions {
         description = "Expressions to compare and return the smallest value. Can be a constant, column, or function, and any combination of arithmetic operators. Pass as many expression arguments as necessary."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LeastFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/named_struct.rs
+++ b/datafusion/functions/src/core/named_struct.rs
@@ -58,7 +58,7 @@ a struct type of fields `field_a` and `field_b`:
         description = "Expression to include in the output struct. Can be a constant, column, or function, and any combination of arithmetic or string operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NamedStructFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/nullif.rs
+++ b/datafusion/functions/src/core/nullif.rs
@@ -53,7 +53,7 @@ This can be used to perform the inverse operation of [`coalesce`](#coalesce).",
         description = "Expression to compare to expression1. Can be a constant, column, or function, and any combination of operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NullIfFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/nvl.rs
+++ b/datafusion/functions/src/core/nvl.rs
@@ -55,7 +55,7 @@ use std::sync::Arc;
         description = "Expression to return if expr1 is null. Can be a constant, column, or function, and any combination of operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NVLFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/core/nvl2.rs
+++ b/datafusion/functions/src/core/nvl2.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
         description = "Expression to return if expr1 is null. Can be a constant, column, or function, and any combination of operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NVL2Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/overlay.rs
+++ b/datafusion/functions/src/core/overlay.rs
@@ -53,7 +53,7 @@ use datafusion_macros::user_doc;
         description = "The count of characters to be replaced from start position of str. If not specified, will use substr length instead."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct OverlayFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/struct.rs
+++ b/datafusion/functions/src/core/struct.rs
@@ -64,7 +64,7 @@ select struct(a as field_a, b) from t;
         description = "Expression to include in the output struct. Can be a constant, column, or function, any combination of arithmetic or string operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct StructFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/core/union_tag.rs
+++ b/datafusion/functions/src/core/union_tag.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 ```"#,
     standard_argument(name = "union", prefix = "Union")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct UnionTagFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/core/version.rs
+++ b/datafusion/functions/src/core/version.rs
@@ -39,7 +39,7 @@ use std::any::Any;
 +--------------------------------------------+
 ```"#
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct VersionFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/digest.rs
+++ b/datafusion/functions/src/crypto/digest.rs
@@ -56,7 +56,7 @@ use std::any::Any;
     - blake3"
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct DigestFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/md5.rs
+++ b/datafusion/functions/src/crypto/md5.rs
@@ -45,7 +45,7 @@ use std::any::Any;
 ```"#,
     standard_argument(name = "expression", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Md5Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/sha224.rs
+++ b/datafusion/functions/src/crypto/sha224.rs
@@ -44,7 +44,7 @@ use std::any::Any;
 ```"#,
     standard_argument(name = "expression", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SHA224Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/sha256.rs
+++ b/datafusion/functions/src/crypto/sha256.rs
@@ -44,7 +44,7 @@ use std::any::Any;
 ```"#,
     standard_argument(name = "expression", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SHA256Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/sha384.rs
+++ b/datafusion/functions/src/crypto/sha384.rs
@@ -44,7 +44,7 @@ use std::any::Any;
 ```"#,
     standard_argument(name = "expression", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SHA384Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/crypto/sha512.rs
+++ b/datafusion/functions/src/crypto/sha512.rs
@@ -44,7 +44,7 @@ use std::any::Any;
 ```"#,
     standard_argument(name = "expression", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SHA512Func {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/current_date.rs
+++ b/datafusion/functions/src/datetime/current_date.rs
@@ -37,7 +37,7 @@ The `current_date()` return value is determined at query time and will return th
 "#,
     syntax_example = "current_date()"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct CurrentDateFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/datetime/current_time.rs
+++ b/datafusion/functions/src/datetime/current_time.rs
@@ -36,7 +36,7 @@ The `current_time()` return value is determined at query time and will return th
 "#,
     syntax_example = "current_time()"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct CurrentTimeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -95,7 +95,7 @@ FROM VALUES ('2023-01-01T18:18:18Z'), ('2023-01-03T19:00:03Z')  t(time);
 "#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct DateBinFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -78,7 +78,7 @@ use datafusion_macros::user_doc;
         description = "Time expression to operate on. Can be a constant, column, or function."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct DatePartFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/datetime/date_trunc.rs
+++ b/datafusion/functions/src/datetime/date_trunc.rs
@@ -67,7 +67,7 @@ use chrono::{
         description = "Time expression to operate on. Can be a constant, column, or function."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct DateTruncFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/datetime/from_unixtime.rs
+++ b/datafusion/functions/src/datetime/from_unixtime.rs
@@ -46,7 +46,7 @@ use datafusion_macros::user_doc;
         description = "Optional timezone to use when converting the integer to a timestamp. If not provided, the default timezone is UTC."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FromUnixtimeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/make_date.rs
+++ b/datafusion/functions/src/datetime/make_date.rs
@@ -66,7 +66,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
         description = "Day to use when making the date. Can be a constant, column or function, and any combination of arithmetic operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct MakeDateFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/now.rs
+++ b/datafusion/functions/src/datetime/now.rs
@@ -37,7 +37,7 @@ The `now()` return value is determined at query time and will return the same ti
 "#,
     syntax_example = "now()"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NowFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -63,7 +63,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
         description = "Day to use when making the date. Can be a constant, column or function, and any combination of arithmetic operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToCharFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -63,7 +63,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
   an error will be returned."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToDateFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/to_local_time.rs
+++ b/datafusion/functions/src/datetime/to_local_time.rs
@@ -96,7 +96,7 @@ FROM (
         description = "Time expression to operate on. Can be a constant, column, or function."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToLocalTimeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -64,7 +64,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
         description = "Optional [Chrono format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) strings to use to parse the expression. Formats will be tried in the order they appear with the first successful one being returned. If none of the formats successfully parse the expression an error will be returned."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToTimestampFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/datetime/to_unixtime.rs
+++ b/datafusion/functions/src/datetime/to_unixtime.rs
@@ -54,7 +54,7 @@ use std::any::Any;
         description = "Optional [Chrono format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) strings to use to parse the expression. Formats will be tried in the order they appear with the first successful one being returned. If none of the formats successfully parse the expression an error will be returned."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToUnixtimeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/encoding/inner.rs
+++ b/datafusion/functions/src/encoding/inner.rs
@@ -54,7 +54,7 @@ use std::any::Any;
     ),
     related_udf(name = "decode")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct EncodeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/macros.rs
+++ b/datafusion/functions/src/macros.rs
@@ -170,7 +170,7 @@ macro_rules! make_math_unary_udf {
                 Signature, Volatility,
             };
 
-            #[derive(Debug)]
+            #[derive(Debug, Clone, PartialEq, Hash)]
             pub struct $UDF {
                 signature: Signature,
             }
@@ -284,7 +284,7 @@ macro_rules! make_math_binary_udf {
                 Signature, Volatility,
             };
 
-            #[derive(Debug)]
+            #[derive(Debug, Clone, PartialEq, Hash)]
             pub struct $UDF {
                 signature: Signature,
             }

--- a/datafusion/functions/src/math/abs.rs
+++ b/datafusion/functions/src/math/abs.rs
@@ -112,7 +112,7 @@ fn create_abs_function(input_data_type: &DataType) -> Result<MathArrayFunction> 
     syntax_example = "abs(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct AbsFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/cot.rs
+++ b/datafusion/functions/src/math/cot.rs
@@ -34,7 +34,7 @@ use datafusion_macros::user_doc;
     syntax_example = r#"cot(numeric_expression)"#,
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct CotFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/factorial.rs
+++ b/datafusion/functions/src/math/factorial.rs
@@ -41,7 +41,7 @@ use datafusion_macros::user_doc;
     syntax_example = "factorial(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FactorialFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/gcd.rs
+++ b/datafusion/functions/src/math/gcd.rs
@@ -37,7 +37,7 @@ use datafusion_macros::user_doc;
     standard_argument(name = "expression_x", prefix = "First numeric"),
     standard_argument(name = "expression_y", prefix = "Second numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct GcdFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/iszero.rs
+++ b/datafusion/functions/src/math/iszero.rs
@@ -38,7 +38,7 @@ use crate::utils::make_scalar_function;
     syntax_example = "iszero(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct IsZeroFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/lcm.rs
+++ b/datafusion/functions/src/math/lcm.rs
@@ -42,7 +42,7 @@ use crate::utils::make_scalar_function;
     standard_argument(name = "expression_x", prefix = "First numeric"),
     standard_argument(name = "expression_y", prefix = "Second numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LcmFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -45,7 +45,7 @@ log(numeric_expression)"#,
     standard_argument(name = "base", prefix = "Base numeric"),
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LogFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/nans.rs
+++ b/datafusion/functions/src/math/nans.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
     syntax_example = "isnan(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct IsNanFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/nanvl.rs
+++ b/datafusion/functions/src/math/nanvl.rs
@@ -45,7 +45,7 @@ Returns the second argument otherwise."#,
         description = "Numeric expression to return if the first expression is _NaN_. Can be a constant, column, or function, and any combination of arithmetic operators."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct NanvlFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/pi.rs
+++ b/datafusion/functions/src/math/pi.rs
@@ -32,7 +32,7 @@ use datafusion_macros::user_doc;
     description = "Returns an approximate value of π.",
     syntax_example = "pi()"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct PiFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/power.rs
+++ b/datafusion/functions/src/math/power.rs
@@ -42,7 +42,7 @@ use datafusion_macros::user_doc;
     standard_argument(name = "base", prefix = "Numeric"),
     standard_argument(name = "exponent", prefix = "Exponent numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct PowerFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/math/random.rs
+++ b/datafusion/functions/src/math/random.rs
@@ -34,7 +34,7 @@ use datafusion_macros::user_doc;
 The random seed is unique to each row."#,
     syntax_example = "random()"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RandomFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/round.rs
+++ b/datafusion/functions/src/math/round.rs
@@ -43,7 +43,7 @@ use datafusion_macros::user_doc;
         description = "Optional. The number of decimal places to round to. Defaults to 0."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RoundFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -40,7 +40,7 @@ Zero and positive numbers return `1`."#,
     syntax_example = "signum(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SignumFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/math/trunc.rs
+++ b/datafusion/functions/src/math/trunc.rs
@@ -47,7 +47,7 @@ use datafusion_macros::user_doc;
   integer, replaces digits to the left of the decimal point with `0`."#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct TruncFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -61,7 +61,7 @@ use std::sync::Arc;
   - **U**: swap the meaning of x* and x*?"#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RegexpCountFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/regex/regexpinstr.rs
+++ b/datafusion/functions/src/regex/regexpinstr.rs
@@ -72,7 +72,7 @@ use crate::regex::compile_and_cache_regex;
         description = "Optional Specifies which capture group (subexpression) to return the position for. Defaults to 0, which returns the position of the entire match."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RegexpInstrFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -67,7 +67,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
   - **U**: swap the meaning of x* and x*?"#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RegexpLikeFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/regex/regexpmatch.rs
+++ b/datafusion/functions/src/regex/regexpmatch.rs
@@ -66,7 +66,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
   - **U**: swap the meaning of x* and x*?"#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RegexpMatchFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -82,7 +82,7 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
 - **U**: swap the meaning of x* and x*?"#
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RegexpReplaceFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/ascii.rs
+++ b/datafusion/functions/src/string/ascii.rs
@@ -49,7 +49,7 @@ use std::sync::Arc;
     standard_argument(name = "str", prefix = "String"),
     related_udf(name = "chr")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct AsciiFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/bit_length.rs
+++ b/datafusion/functions/src/string/bit_length.rs
@@ -45,7 +45,7 @@ use datafusion_macros::user_doc;
     related_udf(name = "length"),
     related_udf(name = "octet_length")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct BitLengthFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/btrim.rs
+++ b/datafusion/functions/src/string/btrim.rs
@@ -65,7 +65,7 @@ fn btrim<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     related_udf(name = "ltrim"),
     related_udf(name = "rtrim")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct BTrimFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -88,7 +88,7 @@ pub fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
     standard_argument(name = "expression", prefix = "String"),
     related_udf(name = "ascii")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ChrFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/concat.rs
+++ b/datafusion/functions/src/string/concat.rs
@@ -52,7 +52,7 @@ use datafusion_macros::user_doc;
     ),
     related_udf(name = "concat_ws")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ConcatFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/concat_ws.rs
+++ b/datafusion/functions/src/string/concat_ws.rs
@@ -59,7 +59,7 @@ use datafusion_macros::user_doc;
     ),
     related_udf(name = "concat")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ConcatWsFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/contains.rs
+++ b/datafusion/functions/src/string/contains.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
     standard_argument(name = "str", prefix = "String"),
     argument(name = "search_str", description = "The string to search for in str.")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ContainsFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/ends_with.rs
+++ b/datafusion/functions/src/string/ends_with.rs
@@ -52,7 +52,7 @@ use datafusion_macros::user_doc;
     standard_argument(name = "str", prefix = "String"),
     argument(name = "substr", description = "Substring to test for.")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct EndsWithFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/levenshtein.rs
+++ b/datafusion/functions/src/string/levenshtein.rs
@@ -57,7 +57,7 @@ use datafusion_macros::user_doc;
         description = "String expression to compute Levenshtein distance with str1."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LevenshteinFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -44,7 +44,7 @@ use datafusion_macros::user_doc;
     related_udf(name = "initcap"),
     related_udf(name = "upper")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LowerFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/ltrim.rs
+++ b/datafusion/functions/src/string/ltrim.rs
@@ -71,7 +71,7 @@ fn ltrim<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     related_udf(name = "btrim"),
     related_udf(name = "rtrim")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LtrimFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/octet_length.rs
+++ b/datafusion/functions/src/string/octet_length.rs
@@ -45,7 +45,7 @@ use datafusion_macros::user_doc;
     related_udf(name = "bit_length"),
     related_udf(name = "length")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct OctetLengthFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -51,7 +51,7 @@ use datafusion_macros::user_doc;
         description = "Number of times to repeat the input string."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RepeatFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -52,7 +52,7 @@ use datafusion_macros::user_doc;
     ),
     standard_argument(name = "replacement", prefix = "Replacement substring")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ReplaceFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/rtrim.rs
+++ b/datafusion/functions/src/string/rtrim.rs
@@ -71,7 +71,7 @@ fn rtrim<T: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     related_udf(name = "btrim"),
     related_udf(name = "ltrim")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RtrimFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/split_part.rs
+++ b/datafusion/functions/src/string/split_part.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
     argument(name = "delimiter", description = "String or character to split on."),
     argument(name = "pos", description = "Position of the part to return.")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SplitPartFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/starts_with.rs
+++ b/datafusion/functions/src/string/starts_with.rs
@@ -74,7 +74,7 @@ fn starts_with(args: &[ArrayRef]) -> Result<ArrayRef> {
     standard_argument(name = "str", prefix = "String"),
     argument(name = "substr", description = "Substring to test for.")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct StartsWithFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/to_hex.rs
+++ b/datafusion/functions/src/string/to_hex.rs
@@ -87,7 +87,7 @@ where
 ```"#,
     standard_argument(name = "int", prefix = "Integer")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ToHexFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -43,7 +43,7 @@ use std::any::Any;
     related_udf(name = "initcap"),
     related_udf(name = "lower")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct UpperFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/string/uuid.rs
+++ b/datafusion/functions/src/string/uuid.rs
@@ -42,7 +42,7 @@ use datafusion_macros::user_doc;
 +--------------------------------------+
 ```"#
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct UuidFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/character_length.rs
+++ b/datafusion/functions/src/unicode/character_length.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
     related_udf(name = "bit_length"),
     related_udf(name = "octet_length")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct CharacterLengthFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/unicode/find_in_set.rs
+++ b/datafusion/functions/src/unicode/find_in_set.rs
@@ -53,7 +53,7 @@ use datafusion_macros::user_doc;
         description = "A string list is a string composed of substrings separated by , characters."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FindInSetFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -50,7 +50,7 @@ use datafusion_macros::user_doc;
     related_udf(name = "lower"),
     related_udf(name = "upper")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct InitcapFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/left.rs
+++ b/datafusion/functions/src/unicode/left.rs
@@ -53,7 +53,7 @@ use datafusion_macros::user_doc;
     argument(name = "n", description = "Number of characters to return."),
     related_udf(name = "right")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LeftFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/lpad.rs
+++ b/datafusion/functions/src/unicode/lpad.rs
@@ -56,7 +56,7 @@ use datafusion_macros::user_doc;
     ),
     related_udf(name = "rpad")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct LPadFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/reverse.rs
+++ b/datafusion/functions/src/unicode/reverse.rs
@@ -44,7 +44,7 @@ use DataType::{LargeUtf8, Utf8, Utf8View};
 ```"#,
     standard_argument(name = "str", prefix = "String")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct ReverseFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/right.rs
+++ b/datafusion/functions/src/unicode/right.rs
@@ -53,7 +53,7 @@ use datafusion_macros::user_doc;
     argument(name = "n", description = "Number of characters to return."),
     related_udf(name = "left")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RightFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/rpad.rs
+++ b/datafusion/functions/src/unicode/rpad.rs
@@ -55,7 +55,7 @@ use DataType::{LargeUtf8, Utf8, Utf8View};
     ),
     related_udf(name = "lpad")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct RPadFunc {
     signature: Signature,
 }

--- a/datafusion/functions/src/unicode/strpos.rs
+++ b/datafusion/functions/src/unicode/strpos.rs
@@ -49,7 +49,7 @@ use datafusion_macros::user_doc;
     standard_argument(name = "str", prefix = "String"),
     argument(name = "substr", description = "Substring expression to search for.")
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct StrposFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -56,7 +56,7 @@ use datafusion_macros::user_doc;
         description = "Number of characters to extract. If not specified, returns the rest of the string after the start position."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SubstrFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/unicode/substrindex.rs
+++ b/datafusion/functions/src/unicode/substrindex.rs
@@ -62,7 +62,7 @@ If count is negative, everything to the right of the final delimiter (counting f
         description = "The number of times to search for the delimiter. Can be either a positive or negative number."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct SubstrIndexFunc {
     signature: Signature,
     aliases: Vec<String>,

--- a/datafusion/functions/src/unicode/translate.rs
+++ b/datafusion/functions/src/unicode/translate.rs
@@ -52,7 +52,7 @@ use datafusion_macros::user_doc;
         description = "Translation characters. Translation characters replace only characters at the same position in the **chars** string."
     )
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct TranslateFunc {
     signature: Signature,
 }

--- a/docs/source/library-user-guide/upgrading.md
+++ b/docs/source/library-user-guide/upgrading.md
@@ -85,7 +85,7 @@ The default implementation of the `equals` method in the `ScalarUDFImpl` trait h
 # use arrow::datatypes::DataType;
 # use std::any::Any;
 #
-# #[derive(Debug)]
+# #[derive(Debug, Clone, PartialEq, Hash)]
 # struct MyUdf {
 #     param: i32,
 # }
@@ -113,14 +113,6 @@ impl ScalarUDFImpl for MyUdf {
 
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         todo!()
-    }
-
-    fn equals(&self, other: &dyn ScalarUDFImpl) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<Self>() {
-            self.param == other.param && self.name() == other.name()
-        } else {
-            false
-        }
     }
 }
 ```


### PR DESCRIPTION
## Summary
- add `UdfEq` and `UdfHash` blanket traits
- extend `ScalarUDFImpl` to use these traits
- remove manual equality and hashing
- derive `PartialEq` and `Hash` for UDF structs
- update docs and tests

## Testing
- `prettier -w {datafusion,datafusion-cli,datafusion-examples,dev,docs}/**/*.md`
- `taplo format --check`
- `cargo test -p datafusion-expr udf_equals -- --nocapture` *(fails: Downloading crates)*


------
https://chatgpt.com/codex/tasks/task_e_687f9e1bf2b4832488c42eac64aa62ca