### PR TITLE
Add MemoryExplain trait

### DIFF
--- a/datafusion/expr-common/Cargo.toml
+++ b/datafusion/expr-common/Cargo.toml
@@ -42,3 +42,4 @@ datafusion-common = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 paste = "^1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/datafusion/expr-common/src/lib.rs
+++ b/datafusion/expr-common/src/lib.rs
@@ -37,6 +37,7 @@ pub mod casts;
 pub mod columnar_value;
 pub mod groups_accumulator;
 pub mod interval_arithmetic;
+pub mod memory;
 pub mod operator;
 pub mod signature;
 pub mod sort_properties;

--- a/datafusion/expr-common/src/memory.rs
+++ b/datafusion/expr-common/src/memory.rs
@@ -1,0 +1,153 @@
+use serde::Serialize;
+
+/// A node in a memory-usage tree, suitable for pretty-printing or JSON serialization.
+#[derive(Debug, Serialize)]
+pub struct MemoryUsage {
+    /// Identifier (e.g. operator name or field)
+    pub name: String,
+    /// Approximate total bytes used by this node
+    pub bytes: usize,
+    /// Breakdown of sub-components
+    pub children: Vec<MemoryUsage>,
+}
+
+/// Trait for explaining memory usage of a component.
+pub trait MemoryExplain {
+    /// Returns the total bytes used by `self`.
+    fn size(&self) -> usize {
+        self.explain_memory().bytes
+    }
+
+    /// Returns a breakdown of memory usage for `self`.
+    fn explain_memory(&self) -> MemoryUsage;
+}
+
+use crate::accumulator::Accumulator;
+use crate::groups_accumulator::GroupsAccumulator;
+
+impl<T: Accumulator + ?Sized> MemoryExplain for T {
+    fn explain_memory(&self) -> MemoryUsage {
+        MemoryUsage {
+            name: std::any::type_name::<T>().to_string(),
+            bytes: Accumulator::size(self),
+            children: vec![],
+        }
+    }
+}
+
+impl<T: GroupsAccumulator + ?Sized> MemoryExplain for T {
+    fn explain_memory(&self) -> MemoryUsage {
+        MemoryUsage {
+            name: std::any::type_name::<T>().to_string(),
+            bytes: GroupsAccumulator::size(self),
+            children: vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accumulator::Accumulator;
+    use crate::groups_accumulator::GroupsAccumulator;
+    use arrow::array::{ArrayRef, BooleanArray};
+    use datafusion_common::{Result, ScalarValue};
+
+    #[derive(Debug)]
+    struct MockAcc {
+        buf: Vec<u8>,
+    }
+
+    impl Default for MockAcc {
+        fn default() -> Self {
+            Self {
+                buf: Vec::with_capacity(4),
+            }
+        }
+    }
+
+    impl Accumulator for MockAcc {
+        fn update_batch(&mut self, _values: &[ArrayRef]) -> Result<()> {
+            Ok(())
+        }
+        fn evaluate(&mut self) -> Result<ScalarValue> {
+            Ok(ScalarValue::from(0u64))
+        }
+        fn state(&mut self) -> Result<Vec<ScalarValue>> {
+            Ok(vec![])
+        }
+        fn merge_batch(&mut self, _states: &[ArrayRef]) -> Result<()> {
+            Ok(())
+        }
+        fn size(&self) -> usize {
+            self.buf.capacity()
+        }
+        fn supports_retract_batch(&self) -> bool {
+            false
+        }
+        fn retract_batch(&mut self, _values: &[ArrayRef]) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_accumulator_memory() {
+        let acc = MockAcc::default();
+        let usage = acc.explain_memory();
+        assert_eq!(usage.bytes, 4);
+    }
+
+    #[derive(Debug)]
+    struct MockGroupsAcc {
+        size: usize,
+    }
+
+    impl GroupsAccumulator for MockGroupsAcc {
+        fn update_batch(
+            &mut self,
+            _values: &[ArrayRef],
+            _groups: &[usize],
+            _filter: Option<&BooleanArray>,
+            _n: usize,
+        ) -> Result<()> {
+            Ok(())
+        }
+        fn evaluate(&mut self, _emit_to: EmitTo) -> Result<ArrayRef> {
+            Err(datafusion_common::DataFusionError::Internal(
+                "not used".into(),
+            ))
+        }
+        fn state(&mut self, _emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+            Ok(vec![])
+        }
+        fn merge_batch(
+            &mut self,
+            _values: &[ArrayRef],
+            _groups: &[usize],
+            _filter: Option<&BooleanArray>,
+            _n: usize,
+        ) -> Result<()> {
+            Ok(())
+        }
+        fn convert_to_state(
+            &self,
+            _values: &[ArrayRef],
+            _filter: Option<&BooleanArray>,
+        ) -> Result<Vec<ArrayRef>> {
+            Ok(vec![])
+        }
+        fn supports_convert_to_state(&self) -> bool {
+            false
+        }
+        fn size(&self) -> usize {
+            self.size
+        }
+    }
+
+    #[test]
+    fn test_groups_acc_memory() {
+        let acc = MockGroupsAcc { size: 8 };
+        let usage = acc.explain_memory();
+        assert_eq!(usage.bytes, 8);
+    }
+}

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -64,6 +64,7 @@ itertools = { workspace = true, features = ["use_std"] }
 log = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = "^0.2.7"
+serde_json = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -205,3 +205,15 @@ pub fn new_group_values(
         Ok(Box::new(GroupValuesRows::try_new(schema)?))
     }
 }
+
+use datafusion_expr_common::memory::{MemoryExplain, MemoryUsage};
+
+impl<T: GroupValues + ?Sized> MemoryExplain for T {
+    fn explain_memory(&self) -> MemoryUsage {
+        MemoryUsage {
+            name: std::any::type_name::<T>().to_string(),
+            bytes: self.size(),
+            children: vec![],
+        }
+    }
+}

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -45,10 +45,12 @@ use datafusion_execution::memory_pool::proxy::VecAllocExt;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::TaskContext;
 use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::memory::{MemoryExplain, MemoryUsage};
 use datafusion_physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::{GroupsAccumulatorAdapter, PhysicalSortExpr};
 use datafusion_physical_expr_common::sort_expr::LexOrdering;
+use serde_json;
 
 use futures::ready;
 use futures::stream::{Stream, StreamExt};
@@ -921,6 +923,13 @@ impl GroupedHashAggregateStream {
                 + self.current_group_indices.allocated_size(),
         );
 
+        if let Err(DataFusionError::ResourcesExhausted(ref e)) = reservation_result {
+            let usage = self.explain_memory();
+            if let Ok(json) = serde_json::to_string(&usage) {
+                log::error!("Memory breakdown: {} -- {}", json, e);
+            }
+        }
+
         if reservation_result.is_ok() {
             self.spill_state
                 .peak_mem_used
@@ -1175,5 +1184,35 @@ impl GroupedHashAggregateStream {
         let states_batch = RecordBatch::try_new(self.schema(), output)?;
 
         Ok(states_batch)
+    }
+}
+
+impl MemoryExplain for GroupedHashAggregateStream {
+    fn explain_memory(&self) -> MemoryUsage {
+        let mut children = Vec::with_capacity(1 + self.accumulators.len());
+        let key_bytes = self.group_values.size();
+        children.push(MemoryUsage {
+            name: "group_keys".into(),
+            bytes: key_bytes,
+            children: vec![],
+        });
+        for (i, acc) in self.accumulators.iter().enumerate() {
+            let mut usage = acc.explain_memory();
+            usage.name = format!("accumulator[{i}] : {}", usage.name);
+            children.push(usage);
+        }
+        let total_bytes: usize = children.iter().map(|c| c.bytes).sum();
+        MemoryUsage {
+            name: "GroupedHashAggregateStream".into(),
+            bytes: total_bytes,
+            children,
+        }
+    }
+}
+
+impl GroupedHashAggregateStream {
+    /// Public entry point for memory introspection.
+    pub fn explain_memory(&self) -> MemoryUsage {
+        MemoryExplain::explain_memory(self)
     }
 }


### PR DESCRIPTION
## Summary
- implement `MemoryExplain` trait in expr-common
- implement for GroupValues and GroupedHashAggregateStream
- log memory breakdown on OOM
- unit tests for mock accumulators

## Testing
- `cargo fmt`
- ❌ `./dev/rust_lint.sh` *(failed: package `icu_provider` requires newer rustc)*
- ❌ `cargo test --quiet` *(failed: lock file version 4 requires newer cargo)*

------
https://chatgpt.com/codex/tasks/task_e_6884529f19288324b9cdb34a5edf445a