### PR TITLE
Wrap object store errors

### DIFF
--- a/datafusion-cli/CONTRIBUTING.md
+++ b/datafusion-cli/CONTRIBUTING.md
@@ -47,7 +47,7 @@ This requires Docker to be running on your machine and port 9000 to be free.
 If you see an error mentioning "failed to load IMDS session token" such as
 
 > ---- object_storage::tests::s3_object_store_builder_resolves_region_when_none_provided stdout ----
-> Error: ObjectStore(Generic { store: "S3", source: "Error getting credentials from provider: an error occurred while loading credentials: failed to load IMDS session token" })
+> Error: ObjectStore(DfObjectStoreError { source: Generic { store: "S3", source: "Error getting credentials from provider: an error occurred while loading credentials: failed to load IMDS session token" }, context: None })
 
 You my need to disable trying to fetch S3 credentials from the environment using the `AWS_EC2_METADATA_DISABLED`, for example:
 

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -331,8 +331,10 @@ impl StatementExecutor {
         let df = match ctx.execute_logical_plan(plan).await {
             Ok(df) => Ok(df),
             Err(DataFusionError::ObjectStore(err))
-                if matches!(err.as_ref(), Generic { store, source: _ } if "S3".eq_ignore_ascii_case(store))
-                    && self.statement_for_retry.is_some() =>
+                if matches!(
+                    err.source.downcast_ref::<object_store::Error>(),
+                    Some(Generic { store, source: _ }) if "S3".eq_ignore_ascii_case(store)
+                ) && self.statement_for_retry.is_some() =>
             {
                 warn!("S3 region is incorrect, auto-detecting the correct region (this may be slow). Consider updating your region configuration.");
                 let plan =

--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -161,10 +161,10 @@ impl CredentialsFromConfig {
         let credentials = config
             .credentials_provider()
             .ok_or_else(|| {
-                DataFusionError::ObjectStore(Box::new(Generic {
+                DataFusionError::from(object_store::Error::Generic {
                     store: "S3",
                     source: "Failed to get S3 credentials aws_config".into(),
-                }))
+                })
             })?
             .clone();
 
@@ -191,10 +191,10 @@ impl CredentialsFromConfig {
                     "Error getting credentials from provider: {e}{source_message}",
                 );
 
-                return Err(DataFusionError::ObjectStore(Box::new(Generic {
+                return Err(DataFusionError::from(object_store::Error::Generic {
                     store: "S3",
                     source: message.into(),
-                })));
+                }));
             }
         };
         Ok(Self {

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -268,7 +268,7 @@ impl ListingTableUrl {
                 let glob_match = self.contains(path, ignore_subdirectory);
                 futures::future::ready(extension_match && glob_match)
             })
-            .map_err(|e| DataFusionError::ObjectStore(Box::new(e)))
+            .map_err(DataFusionError::from)
             .boxed())
     }
 


### PR DESCRIPTION
## Summary
- add `DfObjectStoreError` wrapper for object store errors
- update `DataFusionError::ObjectStore` to use the wrapper
- adjust all conversions and usages to new type
- update docs and tests

## Testing
- `cargo test -p datafusion-common --lib --quiet`
- `cargo test -p datafusion-datasource-csv --lib --quiet`
- `cargo test -p datafusion-datasource --lib --quiet`
- `cargo test -p datafusion-cli --lib --quiet`
- `./dev/rust_lint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68877b0dcf408324b0d9f9142c5281ea