### PR TITLE
feat: re-export object_store crate

### DIFF
--- a/datafusion/common/src/lib.rs
+++ b/datafusion/common/src/lib.rs
@@ -83,6 +83,9 @@ pub use functional_dependencies::{
 use hashbrown::hash_map::DefaultHashBuilder;
 pub use join_type::{JoinConstraint, JoinSide, JoinType};
 pub use null_equality::NullEquality;
+#[cfg(feature = "object_store")]
+/// Reexport object_store crate
+pub use object_store;
 pub use param_value::ParamValues;
 pub use scalar::{ScalarType, ScalarValue};
 pub use schema_reference::SchemaReference;

--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -744,8 +744,16 @@ pub mod physical_planner;
 pub mod prelude;
 pub mod scalar;
 
-// re-export dependencies from arrow-rs to minimize version maintenance for crate users
+// re-export dependencies to minimize version maintenance for crate users
 pub use arrow;
+/// Re-export of the [`object_store`] crate so users can access object store
+/// types without depending on `object_store` directly.
+///
+/// ```no_run
+/// use datafusion::object_store::path::Path;
+/// let _path = Path::from("example");
+/// ```
+pub use object_store;
 #[cfg(feature = "parquet")]
 pub use parquet;
 

--- a/datafusion/core/src/test/object_store.rs
+++ b/datafusion/core/src/test/object_store.rs
@@ -19,14 +19,14 @@
 
 use crate::execution::context::SessionState;
 use crate::execution::session_state::SessionStateBuilder;
-use crate::prelude::SessionContext;
-use futures::stream::BoxStream;
-use futures::FutureExt;
-use object_store::{
+use crate::object_store::{
     memory::InMemory, path::Path, Error, GetOptions, GetResult, ListResult,
     MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions,
     PutPayload, PutResult,
 };
+use crate::prelude::SessionContext;
+use futures::stream::BoxStream;
+use futures::FutureExt;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use tokio::{


### PR DESCRIPTION
## Summary
- re-export `object_store` crate from DataFusion and DataFusion Common
- update internal test utilities to use the new re-export

## Testing
- `taplo format --check`
- `./dev/rust_lint.sh` *(fails: protoc could not find `google/protobuf/any.proto`)*
- `cargo test -p datafusion --lib` *(fails: 113 failed tests)*
- `cargo test -p datafusion --lib --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68947426debc83248d9c943d508e0f69