### PR TITLE
Derive MemoryPool for `Arc<dyn MemoryPool>`

### DIFF
--- a/datafusion/execution/src/memory_pool/mod.rs
+++ b/datafusion/execution/src/memory_pool/mod.rs
@@ -228,6 +228,37 @@ pub enum MemoryLimit {
     Unknown,
 }
 
+/// Implement MemoryPool for Arc<T> where T: MemoryPool
+impl<T: MemoryPool + ?Sized> MemoryPool for Arc<T> {
+    fn register(&self, consumer: &MemoryConsumer) {
+        (**self).register(consumer)
+    }
+
+    fn unregister(&self, consumer: &MemoryConsumer) {
+        (**self).unregister(consumer)
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        (**self).grow(reservation, additional)
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        (**self).shrink(reservation, shrink)
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+        (**self).try_grow(reservation, additional)
+    }
+
+    fn reserved(&self) -> usize {
+        (**self).reserved()
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        (**self).memory_limit()
+    }
+}
+
 /// A memory consumer is a named allocation traced by a particular
 /// [`MemoryReservation`] in a [`MemoryPool`]. All allocations are registered to
 /// a particular `MemoryConsumer`;


### PR DESCRIPTION
This is a suggestion for the following DataFusion PR
- https://github.com/apache/datafusion/pull/17021

Merging this PR will update https://github.com/apache/datafusion/pull/17021

It add a generic implementation for `MemoryPool` for any `Arc<MemoryPool>` instead of a specific struct